### PR TITLE
Native support for raw transaction handling

### DIFF
--- a/src/integ/groovy/com/msgilligan/bitcoin/rpc/BitcoinSpec.groovy
+++ b/src/integ/groovy/com/msgilligan/bitcoin/rpc/BitcoinSpec.groovy
@@ -38,11 +38,29 @@ class BitcoinSpec extends BaseRegTestSpec {
         // TODO: check balance of source address/wallet
     }
 
-    def "Get a list of unspent Transactions"() {
-        when: "we request unspent Transactions"
+    def "Get a list of unspent transaction outputs"() {
+        when: "we request unspent transaction outputs"
         def unspent = listUnspent()
 
         then: "there is at least 1"
         unspent.size() >= 1
+    }
+
+    def "Get a filtered list of unconfirmed transaction outputs"() {
+        when: "we create a new address and send #testAmount to it"
+        def destinationAddress = getNewAddress()
+        sendToAddress(destinationAddress, testAmount, "comment", "comment-to")
+
+        and: "we request unconfirmed unspent outputs for #destinationAddress"
+        def unspent = listUnspent(0, 0, [destinationAddress])
+
+        then: "there is at least 1"
+        unspent.size() >= 1
+
+        and: "they have 0 confirmations"
+        unspent.every { output -> output.confirmations == 0 }
+
+        and: "they are associated with #destinationAddress"
+        unspent.every { output -> output.address == destinationAddress.toString() }
     }
 }

--- a/src/main/groovy/org/mastercoin/test/TestSupport.groovy
+++ b/src/main/groovy/org/mastercoin/test/TestSupport.groovy
@@ -86,4 +86,35 @@ trait TestSupport implements MastercoinClientDelegate {
 
         return address
     }
+
+    /**
+     * Returns the Bitcoin balance of an address.
+     *
+     * @param address The address
+     * @return The balance
+     */
+    BigDecimal getBitcoinBalance(Address address) {
+        return getBitcoinBalance(address, 1, 99999)
+    }
+
+    /**
+     * Returns the Bitcoin balance of an address where spendable outputs have at least {@code minConf} and not more
+     * than {@code maxConf} confirmations.
+     *
+     * @param address The address
+     * @param minConf Minimum amount of confirmations
+     * @param maxConf Maximum amount of confirmations
+     * @return The balance
+     */
+    BigDecimal getBitcoinBalance(Address address, Integer minConf, Integer maxConf) {
+        def btcBalance = new BigDecimal(0)
+        def unspentOutputs = (List<Map<String, Object>>) listUnspent(minConf, maxConf, [address])
+
+        for (unspentOutput in unspentOutputs) {
+            def balanceBTCd = unspentOutput["amount"] as Double
+            btcBalance += BigDecimal.valueOf(balanceBTCd)
+        }
+
+        return btcBalance
+    }
 }

--- a/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -194,6 +194,23 @@ public class BitcoinClient extends RPCClient {
         return result;
     }
 
+    /**
+     * Signs inputs of a raw transaction.
+     *
+     * @param unsignedTransaction The hex-encoded raw transaction
+     * @return The signed transaction and information whether it has a complete set of signature
+     * @throws IOException
+     * @throws JsonRPCException
+     */
+    public Map<String, Object> signRawTransaction(String unsignedTransaction) throws IOException, JsonRPCException {
+        List<Object> params = createParamList(unsignedTransaction);
+        Map<String, Object> response = send("signrawtransaction", params);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> signedTransaction = (Map<String, Object>) response.get("result");
+        return signedTransaction;
+    }
+
     public Object getRawTransaction(Sha256Hash txid, Boolean verbose) throws JsonRPCException, IOException {
         Object result;
         if (verbose) {

--- a/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -268,18 +268,56 @@ public class BitcoinClient extends RPCClient {
         return addresses;
     }
 
-    public List<Object> listUnspent() throws JsonRPCException, IOException {
-        return listUnspent(null, null);
+    /**
+     * Returns a list of unspent transaction outputs with at least one confirmation.
+     *
+     * @return The unspent transaction outputs
+     * @throws JsonRPCException
+     * @throws IOException
+     */
+    public List<Map<String, Object>> listUnspent() throws JsonRPCException, IOException {
+        return listUnspent(null, null, null);
     }
 
-    public List<Object> listUnspent(Integer minConf, Integer maxConf) throws JsonRPCException, IOException {
-        List<Object> params = createParamList(minConf, maxConf);
+    /**
+     * Returns a list of unspent transaction outputs with at least {@code minConf} and not more than {@code maxConf}
+     * confirmations.
+     *
+     * @param minConf The minimum confirmations to filter
+     * @param maxConf The maximum confirmations to filter
+     * @return The unspent transaction outputs
+     * @throws JsonRPCException
+     * @throws IOException
+     */
+    public List<Map<String, Object>> listUnspent(Integer minConf, Integer maxConf)
+            throws JsonRPCException, IOException {
+        return listUnspent(minConf, maxConf, null);
+    }
+
+    /**
+     * Returns a list of unspent transaction outputs with at least {@code minConf} and not more than {@code maxConf}
+     * confirmations, filtered by a list of addresses.
+     *
+     * @param minConf The minimum confirmations to filter
+     * @param maxConf The maximum confirmations to filter
+     * @param filter  Include only transaction outputs to the specified addresses
+     * @return The unspent transaction outputs
+     * @throws JsonRPCException
+     * @throws IOException
+     */
+    public List<Map<String, Object>> listUnspent(Integer minConf, Integer maxConf, Iterable<Address> filter)
+            throws JsonRPCException, IOException {
+        List<String> addressFilter = null;
+        if (null != filter) addressFilter = applyToString(filter);
+
+        List<Object> params = createParamList(minConf, maxConf, addressFilter);
         Map<String, Object> response = send("listunspent", params);
 
         @SuppressWarnings("unchecked")
-        List<Object> unspent = (List<Object>) response.get("result");
+        List<Map<String, Object>> unspent = (List<Map<String, Object>>) response.get("result");
         return unspent;
     }
+
     public BigDecimal getBalance() throws JsonRPCException, IOException {
         return getBalance(null, null);
     }
@@ -384,6 +422,21 @@ public class BitcoinClient extends RPCClient {
             formatter.close();
         }
         return sb.toString();
+    }
+
+    /**
+     * Applies toString() to every element of {@code elements} and returns a list of the results.
+     *
+     * @param elements The elements
+     * @return The list of strings
+     */
+    private <T> List<String> applyToString(Iterable<T> elements) {
+        List<String> stringList = new ArrayList<>();
+        for (T element : elements) {
+            String elementAsString = element.toString();
+            stringList.add(elementAsString);
+        }
+        return stringList;
     }
 
 }

--- a/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -254,8 +254,16 @@ public class BitcoinClient extends RPCClient {
         return sendRawTransaction(tx, null);
     }
 
+    public Sha256Hash sendRawTransaction(String hexTx) throws JsonRPCException, IOException {
+        return sendRawTransaction(hexTx, null);
+    }
+
     public Sha256Hash sendRawTransaction(Transaction tx, Boolean allowHighFees) throws JsonRPCException, IOException {
         String hexTx = transactionToHex(tx);
+        return sendRawTransaction(hexTx, allowHighFees);
+    }
+
+    public Sha256Hash sendRawTransaction(String hexTx, Boolean allowHighFees) throws JsonRPCException, IOException {
         List<Object> params = createParamList(hexTx, allowHighFees);
         Map<String, Object> response = send("sendrawtransaction", params);
 

--- a/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -225,7 +225,7 @@ public class BitcoinClient extends RPCClient {
 
     /* TODO: Return a stronger type than an a Map? */
     public Map<String, Object> getRawTransactionMap(Sha256Hash txid) throws JsonRPCException, IOException {
-        List<Object> params = createParamList(txid, 1);
+        List<Object> params = createParamList(txid.toString(), 1);
         Map<String, Object> response = send("getrawtransaction", params);
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -195,6 +195,27 @@ public class BitcoinClient extends RPCClient {
     }
 
     /**
+     * Creates a raw transaction spending the given inputs to the given destinations.
+     *
+     * Note: the transaction inputs are not signed, and the transaction is not stored in the wallet or transmitted to
+     * the network.
+     *
+     * @param inputs  The outpoints to spent
+     * @param outputs The destinations and amounts to transfer
+     * @return The hex-encoded raw transaction
+     * @throws JsonRPCException
+     * @throws IOException
+     */
+    public String createRawTransaction(List<Object> inputs, Map<Address, BigDecimal> outputs)
+            throws JsonRPCException, IOException {
+        List<Object> params = Arrays.asList(inputs, outputs);
+        Map<String, Object> response = send("createrawtransaction", params);
+
+        String transactionHex = (String) response.get("result");
+        return transactionHex;
+    }
+
+    /**
      * Signs inputs of a raw transaction.
      *
      * @param unsignedTransaction The hex-encoded raw transaction


### PR DESCRIPTION
New or updated methods:

- BigDecimal getBitcoinBalance(Address address)
- BigDecimal getBitcoinBalance(Address address, Integer minConf, Integer maxConf)
- List\<Map\<String, Object>> listUnspent()
- List\<Map\<String, Object>> listUnspent(Integer minConf, Integer maxConf)
- List\<Map\<String, Object>> listUnspent(Integer minConf, Integer maxConf, Iterable\<Address> filter)
- Map\<String, Object> signRawTransaction(String unsignedTransaction)
- Sha256Hash sendRawTransaction(String hexTx)
- String createRawTransaction(Address fromAddress, Address toAddress, BigDecimal amount)
- String createRawTransaction(Address fromAddress, Map\<Address, BigDecimal> outputs)
- String createRawTransaction(List\<Object> inputs, Map\<Address, BigDecimal> outputs)

Most of it is in action in the specification BitcoinRawTransactionSpec.