### PR TITLE
Add and test "sendBitcoin" to transfer BTC without new change address

### DIFF
--- a/src/integ/groovy/com/msgilligan/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
+++ b/src/integ/groovy/com/msgilligan/bitcoin/rpc/BitcoinRawTransactionSpec.groovy
@@ -77,4 +77,24 @@ class BitcoinRawTransactionSpec extends BaseRegTestSpec {
         def balanceDestination = getBitcoinBalance(destinationAddress)
         balanceDestination == sendingAmount
     }
+
+    def "Send Bitcoin"() {
+        when: "a new address is created"
+        def newAddress = getNewAddress()
+
+        and: "coins are sent to the new address from #destinationAddress"
+        def amount = sendingAmount - stdTxFee
+        sendBitcoin(destinationAddress, newAddress, amount)
+
+        and: "a new block is mined"
+        generateBlock()
+
+        then: "the sending address should be empty"
+        def balanceSource = getBitcoinBalance(destinationAddress)
+        balanceSource == 0
+
+        and: "the new adress should have the amount sent to"
+        def balance = getBitcoinBalance(newAddress)
+        balance == amount
+    }
 }

--- a/src/main/groovy/org/mastercoin/test/TestSupport.groovy
+++ b/src/main/groovy/org/mastercoin/test/TestSupport.groovy
@@ -139,7 +139,9 @@ trait TestSupport implements MastercoinClientDelegate {
 
         // Calculate change
         def amountChange = amountIn - amountOut - stdTxFee
-        outputs[fromAddress] = amountChange
+        if (amountChange > 0) {
+            outputs[fromAddress] = amountChange
+        }
 
         return createRawTransaction(inputs, outputs)
     }

--- a/src/main/groovy/org/mastercoin/test/TestSupport.groovy
+++ b/src/main/groovy/org/mastercoin/test/TestSupport.groovy
@@ -176,4 +176,39 @@ trait TestSupport implements MastercoinClientDelegate {
 
         return btcBalance
     }
+
+    /**
+     * Sends BTC from an address to a destination, whereby no new change address is created, and any leftover is
+     * returned to the sending address.
+     *
+     * @param fromAddress The source to spent from
+     * @param toAddress   The destination address
+     * @param amount      The amount to transfer
+     * @return The transaction hash
+     */
+    Sha256Hash sendBitcoin(Address fromAddress, Address toAddress, BigDecimal amount) {
+        def outputs = new HashMap<Address, BigDecimal>()
+        outputs[toAddress] = amount
+        return sendBitcoin(fromAddress, outputs)
+    }
+
+    /**
+     * Sends BTC from an address to the destinations, whereby no new change address is created, and any leftover is
+     * returned to the sending address.
+     *
+     * @param fromAddress The source to spent from
+     * @param outputs     The destinations and amounts to transfer
+     * @return The transaction hash
+     */
+    Sha256Hash sendBitcoin(Address fromAddress, Map<Address, BigDecimal> outputs) {
+        def unsignedTxHex = createRawTransaction(fromAddress, outputs)
+        def signingResult = signRawTransaction(unsignedTxHex)
+
+        assert signingResult["complete"] == true
+
+        def signedTxHex = signingResult["hex"] as String
+        def txid = sendRawTransaction(signedTxHex)
+
+        return txid
+    }
 }


### PR DESCRIPTION
Refined:
 - String createRawTransaction(Address fromAddress, Map<Address, BigDecimal> outputs)

New:
 - Sha256Hash sendBitcoin(Address fromAddress, Address toAddress, BigDecimal amount)
 - Sha256Hash sendBitcoin(Address fromAddress, Map\<Address, BigDecimal> outputs)

Test:
- BitcoinRawTransactionSpec: "Send Bitcoin"