### PR TITLE
Tweak type handling

### DIFF
--- a/src/integ/groovy/org/mastercoin/test/rpc/MSCSimpleSendSpec.groovy
+++ b/src/integ/groovy/org/mastercoin/test/rpc/MSCSimpleSendSpec.groovy
@@ -10,6 +10,7 @@ import org.mastercoin.MPNetworkParameters
 import org.mastercoin.MPRegTestParams
 import org.mastercoin.rpc.MPBalanceEntry
 import spock.lang.Shared
+import spock.lang.Unroll
 
 import static org.mastercoin.CurrencyID.*
 
@@ -23,15 +24,13 @@ class MSCSimpleSendSpec extends BaseRegTestSpec {
     final static BigDecimal faucetBTC = 10.0
     final static BigDecimal faucetMSC = 1000.0
 
-
-    def "Can simple send MSC from one address to another" () {
+    @Unroll
+    def "Can simple send #amount MSC from one address to another"() {
         setup:
-        def faucetAddress = createFundedAddress(faucetBTC, faucetMSC)
-
+        def faucetAddress = createFundedAddress(faucetBTC, fundingMSC)
 
         when: "we send MSC"
         def startBalance = getbalance_MP(faucetAddress, MSC).balance
-        def amount = 1.0
         def toAddress = getNewAddress()
         send_MP(faucetAddress, toAddress, MSC, amount)
 
@@ -42,6 +41,12 @@ class MSCSimpleSendSpec extends BaseRegTestSpec {
         then: "the toAddress has the correct MSC balance and source address is reduced by right amount"
         amount == getbalance_MP(toAddress, MSC).balance
         endBalance == startBalance - amount
+
+        where:
+        fundingMSC | amount
+        1000.0     | 1.0
+        1.0        | 0.12345678
+        0.000001   | 0.00000001
     }
 
     def "When the amount to transfer is zero Simple Sends are rejected by the RPC"() {

--- a/src/main/java/org/mastercoin/CurrencyID.java
+++ b/src/main/java/org/mastercoin/CurrencyID.java
@@ -82,7 +82,7 @@ public final class CurrencyID extends Number implements Cloneable {
 
     @Override
     public String toString() {
-        return "CurrencyID:" + Integer.toString(this.intValue());
+        return "CurrencyID:" + Long.toString(value);
     }
 
 }

--- a/src/main/java/org/mastercoin/Ecosystem.java
+++ b/src/main/java/org/mastercoin/Ecosystem.java
@@ -60,4 +60,10 @@ public class Ecosystem extends Number {
         }
         return this.value == ((Ecosystem)obj).value;
     }
+
+    @Override
+    public String toString() {
+        return "Ecosystem:" + Short.toString(value);
+    }
+
 }

--- a/src/main/java/org/mastercoin/PropertyType.java
+++ b/src/main/java/org/mastercoin/PropertyType.java
@@ -12,16 +12,12 @@ public class PropertyType extends Number {
     public static final PropertyType INDIVISIBLE = new PropertyType(INDIVISIBLE_VALUE);
     public static final PropertyType DIVISIBLE = new PropertyType(DIVISIBLE_VALUE);
 
-    public PropertyType(short value) {
+    public PropertyType(int value) {
         if (!(value == INDIVISIBLE_VALUE ||
               value == DIVISIBLE_VALUE)) {
             throw new NumberFormatException();
         }
         this.value = value;
-    }
-
-    public PropertyType(int value) {
-        this((short) value);
     }
 
     @Override
@@ -59,4 +55,10 @@ public class PropertyType extends Number {
         }
         return this.value == ((PropertyType)obj).value;
     }
+
+    @Override
+    public String toString() {
+        return "PropertyType:" + Integer.toString(value);
+    }
+
 }

--- a/src/main/java/org/mastercoin/rpc/MastercoinClient.java
+++ b/src/main/java/org/mastercoin/rpc/MastercoinClient.java
@@ -54,7 +54,7 @@ public class MastercoinClient extends BitcoinClient {
     }
 
     public Sha256Hash send_MP(Address fromAddress, Address toAddress, CurrencyID currency, BigDecimal amount) throws JsonRPCException, IOException {
-        List<Object> params = Arrays.asList((Object) fromAddress.toString(), toAddress.toString(), currency.longValue(), amount.toString());
+        List<Object> params = Arrays.asList((Object) fromAddress.toString(), toAddress.toString(), currency.longValue(), amount.toPlainString());
         Map<String, Object> response = send("send_MP", params);
         String txid = (String) response.get("result");
         Sha256Hash hash = new Sha256Hash(txid);
@@ -135,7 +135,7 @@ public class MastercoinClient extends BitcoinClient {
     }
 
     public Sha256Hash sendToOwnersMP(Address fromAddress, CurrencyID currency, BigDecimal amount) throws JsonRPCException, IOException {
-        List<Object> params = Arrays.asList((Object) fromAddress.toString(), currency.longValue(), amount.toString());
+        List<Object> params = Arrays.asList((Object) fromAddress.toString(), currency.longValue(), amount.toPlainString());
         Map<String, Object> response = send("sendtoowners_MP", params);
         String txid = (String) response.get("result");
         Sha256Hash hash = new Sha256Hash(txid);

--- a/src/test/groovy/org/mastercoin/CurrencyIDSpec.groovy
+++ b/src/test/groovy/org/mastercoin/CurrencyIDSpec.groovy
@@ -138,4 +138,18 @@ class CurrencyIDSpec extends Specification {
         id << [0, -1, 4294967296]
     }
 
+    def "A CurrencyID can be represented as String"() {
+        expect:
+        CurrencyID currency = new CurrencyID(id)
+        currency.toString() == currencyIdAsString
+
+        where:
+        id | currencyIdAsString
+        1 | "CurrencyID:1"
+        2 | "CurrencyID:2"
+        2147483647 | "CurrencyID:2147483647"
+        2147483647L + 1 | "CurrencyID:2147483648"
+        4294967295 | "CurrencyID:4294967295"
+    }
+
 }

--- a/src/test/groovy/org/mastercoin/EcosystemSpec.groovy
+++ b/src/test/groovy/org/mastercoin/EcosystemSpec.groovy
@@ -68,6 +68,17 @@ class EcosystemSpec extends Specification {
 
         where:
         id << [0, -1, 3]
-
     }
+
+    def "An Ecosystem can be represented as String"() {
+        expect:
+        Ecosystem ecosystem = new Ecosystem(id)
+        ecosystem.toString() == ecosystemAsString
+
+        where:
+        id | ecosystemAsString
+        1  | "Ecosystem:1"
+        2  | "Ecosystem:2"
+    }
+
 }


### PR DESCRIPTION
There were a few places where a number was converted into a too small type.

When sending a very small amount via send_MP (...) it would have been converted
into "9.9E-7" instead of "0.00000099" before sending, thus "toPlainString" was
used.

The "native" Master/Omni type objects (CurrencyID, Ecosystem, PropertyType) have
two constructors now: one for the underlying value type, and one that can be
called with the more general "Number" interface.

The "Number" interface is also used for the property creation, where no "native"
type object (in this case "Number of Coins") is yet in place, so it doesn't
matter, whether it's called with an "Integer", "Long", "BigDecimal", etc., which
are converted into a hex string anyway.

"Ecosystem" and "PropertyType" have a "toString" method, which simply returns
"Ecosystem:1" or "PropertyType:2". It should be discussed, if something like
"Main Ecosystem" or "Indivisible Property" would be more suitable.