### PR TITLE
Support creating STO transaction based on raw transaction data

### DIFF
--- a/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToOwnersSpec.groovy
+++ b/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToOwnersSpec.groovy
@@ -2,6 +2,7 @@ package foundation.omni.test.rpc.sto
 
 import com.msgilligan.bitcoin.rpc.JsonRPCStatusException
 import foundation.omni.BaseRegTestSpec
+import foundation.omni.CurrencyID
 import foundation.omni.consensus.ConsensusTool
 import foundation.omni.consensus.MasterCoreConsensusTool
 import spock.lang.Shared
@@ -75,6 +76,15 @@ class MSCSendToOwnersSpec extends BaseRegTestSpec {
 
         then: "balances unchanged"
         startBalances == endBalances
+    }
+
+    def "The generated hex-encoded transaction matches a valid reference transaction"() {
+        given:
+        def txHex = createSendToOwnersHex(new CurrencyID(6), 100000000000L)
+        def expectedHex = "0000000300000006000000174876e800"
+
+        expect:
+        txHex == expectedHex
     }
 
 }

--- a/src/main/groovy/foundation/omni/test/TestSupport.groovy
+++ b/src/main/groovy/foundation/omni/test/TestSupport.groovy
@@ -265,6 +265,19 @@ trait TestSupport implements MastercoinClientDelegate {
     }
 
     /**
+     * Creates and broadcasts a "send to owners" transaction.
+     *
+     * @param currencyId  The identifier of the currency
+     * @param amount      The number of tokens to distribute
+     * @return The transaction hash
+     */
+    Sha256Hash sendToOwners(Address address, CurrencyID currencyId, Long amount) {
+        def rawTxHex = createSendToOwnersHex(currencyId, amount);
+        def txid = sendrawtx_MP(address, rawTxHex)
+        return txid
+    }
+
+    /**
      * Creates an offer on the traditional distributed exchange.
      *
      * @param address        The address
@@ -312,6 +325,14 @@ trait TestSupport implements MastercoinClientDelegate {
         def rawTxHex = createPropertyHex(ecosystem, type, 0L, "", "", label, "", "", amount);
         def txid = sendrawtx_MP(address, rawTxHex)
         return txid
+    }
+
+    /**
+     * Creates a hex-encoded raw transaction of type 3: "send to owners".
+     */
+    String createSendToOwnersHex(CurrencyID currencyId, Long amount) {
+        def rawTxHex = String.format("00000003%08x%016x", currencyId.longValue(), amount)
+        return rawTxHex
     }
 
     /**


### PR DESCRIPTION
Similar to createProperty, createPropertyHex, createDexSellOffer and createDexSellOfferHex,
this PR adds support for creating raw STO transactions.

This is useful to bypass the RPC layer.

TestSupport:
- Sha256Hash sendToOwners(Address address, CurrencyID currencyId, Long amount)
- String createSendToOwnersHex(CurrencyID currencyId, Long amount)

MSCSendToOwnersSpec:
- "The generated hex-encoded transaction matches a valid reference transaction"