### PR TITLE
Finalize STO test plan and add missing tests

### DIFF
--- a/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToManyOwnersSpec.groovy
+++ b/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToManyOwnersSpec.groovy
@@ -5,6 +5,7 @@ import foundation.omni.BaseRegTestSpec
 import foundation.omni.CurrencyID
 import foundation.omni.Ecosystem
 import foundation.omni.PropertyType
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static foundation.omni.CurrencyID.MSC

--- a/src/main/java/foundation/omni/CurrencyID.java
+++ b/src/main/java/foundation/omni/CurrencyID.java
@@ -6,7 +6,7 @@ package foundation.omni;
 public final class CurrencyID extends Number implements Cloneable {
     private final long value;
 
-    public static final long   MIN_VALUE = 1;
+    public static final long   MIN_VALUE = 0;
     public static final long   MAX_VALUE = 4294967295L;
 
     public static final long   MAX_REAL_ECOSYSTEM_VALUE = 2147483647;

--- a/src/test/groovy/foundation/omni/CurrencyIDSpec.groovy
+++ b/src/test/groovy/foundation/omni/CurrencyIDSpec.groovy
@@ -135,7 +135,7 @@ class CurrencyIDSpec extends Specification {
         NumberFormatException e = thrown()
 
         where:
-        id << [0, -1, 4294967296]
+        id << [-1, 4294967296]
     }
 
     def "A CurrencyID can be represented as String"() {


### PR DESCRIPTION
See #34 regarding the CurrencyID and Bitcoin.

This PR adds the missing invalidation tests for "send to owners":
- STO Property ID is non-existent
- STO Property ID is 0 - bitcoin
- Sender owns all the coins of the STO Property, other addresses had non-zero balances but now zero balances

It integrates well into the test setup and the tests can also be tested with raw transactions, when running the -TestPlanRawSpec.

Two tests are ignored until #35 is solved.