### PR TITLE
STO invalidation test: actor has not enough TMSC to pay for fees

### DIFF
--- a/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToOwnersTestPlanSpec.groovy
+++ b/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToOwnersTestPlanSpec.groovy
@@ -271,12 +271,7 @@ class MSCSendToOwnersTestPlanSpec extends BaseRegTestSpec {
                 requestMSC(actorAddress, numberOfTokens)
                 generateBlock()
             }
-
-            if (propertyName == "MSC") {
-                return CurrencyID.MSC;
-            } else {
-                return CurrencyID.TMSC;
-            }
+            return CurrencyID.valueOf(propertyName)
         }
 
         numberOfTokens += amountAvailable

--- a/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToOwnersTestPlanSpec.groovy
+++ b/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToOwnersTestPlanSpec.groovy
@@ -44,7 +44,7 @@ class MSCSendToOwnersTestPlanSpec extends BaseRegTestSpec {
         def startMSC = mscAvailable + mscReserved
         def actorAddress = createFundedAddress(startBTC, startMSC)
         def currencyMSC = new CurrencyID(ecosystem.longValue())
-        def currencySPT = createStoProperty(actorAddress, data)
+        def currencySPT = getStoProperty(actorAddress, data)
 
         // Create a DEx offer to reserve an amount
         if (mscReserved > 0) {
@@ -252,19 +252,34 @@ class MSCSendToOwnersTestPlanSpec extends BaseRegTestSpec {
     }
 
     /**
-     * Creates a new property and returns it's identifier.
+     * Parses the property identifier and creates a new property, if it's neither MSC or TMSC.
      */
-    def createStoProperty(Address actorAddress, def data) {
+    def getStoProperty(Address actorAddress, def data) {
         def amountAvailableOwners = Eval.me(data.AmountAvailableOwners) as List<BigDecimal>
         def amountAvailable = new BigDecimal(data.AmountAvailable)
         def ecosystem = new Ecosystem(Short.valueOf(data.Ecosystem))
         def propertyType = new PropertyType(Integer.valueOf(data.PropertyType))
-
-        def numberOfTokens = amountAvailable
+        def propertyName = new String(data.PropertyName)
+        def numberOfTokens = 0.0
 
         if (amountAvailableOwners.size()) {
             numberOfTokens += amountAvailableOwners.sum()
         }
+
+        if (propertyName == "MSC" || propertyName == "TMSC") {
+            if (numberOfTokens > 0) {
+                requestMSC(actorAddress, numberOfTokens)
+                generateBlock()
+            }
+
+            if (propertyName == "MSC") {
+                return CurrencyID.MSC;
+            } else {
+                return CurrencyID.TMSC;
+            }
+        }
+
+        numberOfTokens += amountAvailable
 
         if (propertyType == PropertyType.DIVISIBLE) {
             numberOfTokens = BTC.btcToSatoshis(numberOfTokens)

--- a/src/integ/groovy/foundation/omni/test/rpc/sto/sto-testplan.tsv
+++ b/src/integ/groovy/foundation/omni/test/rpc/sto/sto-testplan.tsv
@@ -5,6 +5,7 @@ Sender STO amount exceeds the number owned and available by the sending address,
 Sender does not have a sufficient MSC available balance to pay the transfer fee, MSC reserved balance > 0	2	2	TDiv1	1.0	0.0	1.0	0.00000001	0.0	2	[1.0, 1.0]	[0.0, 0.0]	false	false	1.0	0.0	0.00000001	0.0	[1.0, 1.0]	[0.0, 0.0]
 Sender MSC available balance = 0, MSC reserved balance > 0	2	2	TDiv1	1.0	0.0	0.1	0.0	0.1	2	[1.0, 1.0]	[0.0, 0.0]	false	false	1.0	0.0	0.0	0.1	[1.0, 1.0]	[0.0, 0.0]
 Sender owns all the coins of the STO Property after issuance (tx50, tx55) but before any distributions/sends	2	2	TDiv1	1.0	0.0	0.1	1.0	0.0	0	[]	[]	false	false	1.0	0.0	1.0	0.0	[]	[]
+Sender does not have sufficient MSC for STO amount + transfer fee	2	2	TMSC	0.000001	0.0	0.000001	0.000001	0.0	1	[1.0]	[0.0]	false	false	0.000001	0.0	0.000001	0.0	[1.0]	[0.0]
 One receiving owner (available balance > 0)	2	2	TDiv1	92233720368.54775806	0.0	0.00000001	0.1	0.0	1	[0.00000001]	[0.0]	false	true	92233720368.54775805	0.0	0.09999999	0.0	[0.00000002]	[0.0]
 Two equal owners (available balance > 0, amount divisible by number of owners)	2	2	TDiv2	90000000000.0	0.0	10000000000.0	0.1	0.0	2	[1.0, 1.0]	[0.0, 0.0]	false	true	80000000000.0	0.0	0.09999998	0.0	[5000000001.0, 5000000001.0]	[0.0, 0.0]
 Three equal owners (available balance > 0,  amount divisible by number of owners)	2	2	TDiv2	80000000000.0	0.0	333.3	0.1	0.0	3	[1.0, 1.0, 1.0]	[0.0, 0.0, 0.0]	false	true	79999999666.7	0.0	0.09999997	0.0	[112.1, 112.1, 112.1]	[0.0, 0.0, 0.0]

--- a/src/main/groovy/foundation/omni/test/TestSupport.groovy
+++ b/src/main/groovy/foundation/omni/test/TestSupport.groovy
@@ -25,7 +25,7 @@ trait TestSupport implements MastercoinClientDelegate {
         return accountName
     }
 
-    def requestBitcoin(Address toAddress, BigDecimal requestedBTC) {
+    Sha256Hash requestBitcoin(Address toAddress, BigDecimal requestedBTC) {
         def amountGatheredSoFar = 0.0
         def inputs = new ArrayList<Map<String, Object>>()
 
@@ -65,6 +65,18 @@ trait TestSupport implements MastercoinClientDelegate {
         def signedTxHex = signingResult.hex as String
         def txid = client.sendRawTransaction(signedTxHex, true)
 
+        return txid
+    }
+
+    Sha256Hash requestMSC(Address toAddress, BigDecimal requestedMSC) {
+        final MPNetworkParameters params = MPRegTestParams.get()  // Hardcoded for RegTest for now
+
+        // TODO: avoid inaccurate funding
+        // TODO: integrate into createFundedAddress
+        def btcForMSC = (requestedMSC / 100).setScale(8, BigDecimal.ROUND_UP)
+        requestBitcoin(toAddress, btcForMSC + stdTxFee)
+
+        def txid = sendBitcoin(toAddress, params.moneyManAddress, btcForMSC)
         return txid
     }
 

--- a/src/main/java/foundation/omni/CurrencyID.java
+++ b/src/main/java/foundation/omni/CurrencyID.java
@@ -24,6 +24,22 @@ public final class CurrencyID extends Number implements Cloneable {
     public static final CurrencyID  MaidSafeCoin = new CurrencyID(MaidSafeCoin_VALUE);
     public static final CurrencyID  TetherUS = new CurrencyID(TetherUS_VALUE);
 
+    public static CurrencyID valueOf(String s) {
+        switch (s) {
+            case "BTC":
+                return BTC;
+            case "MSC":
+                return MSC;
+            case "TMSC":
+                return TMSC;
+            case "MaidSafeCoin":
+                return MaidSafeCoin;
+            case "TetherUS":
+                return TetherUS;
+        }
+        throw new NumberFormatException();
+    }
+
     public CurrencyID(long value) {
         if (value < MIN_VALUE) {
             throw new NumberFormatException();

--- a/src/test/groovy/foundation/omni/CurrencyIDSpec.groovy
+++ b/src/test/groovy/foundation/omni/CurrencyIDSpec.groovy
@@ -1,6 +1,7 @@
 package foundation.omni
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * User: sean
@@ -150,6 +151,22 @@ class CurrencyIDSpec extends Specification {
         2147483647 | "CurrencyID:2147483647"
         2147483647L + 1 | "CurrencyID:2147483648"
         4294967295 | "CurrencyID:4294967295"
+    }
+
+    @Unroll
+    def "The String \"#str\" can be used to create CurrencyID:#value"() {
+
+        expect:
+        CurrencyID currency = CurrencyID.valueOf(str)
+        currency.longValue() == value
+
+        where:
+        str            | value
+        "BTC"          | CurrencyID.BTC_VALUE
+        "MSC"          | CurrencyID.MSC_VALUE
+        "TMSC"         | CurrencyID.TMSC_VALUE
+        "MaidSafeCoin" | CurrencyID.MaidSafeCoin_VALUE
+        "TetherUS"     | CurrencyID.TetherUS_VALUE
     }
 
 }


### PR DESCRIPTION
See #39.

This further adds `CurrencyID.valueOf(String s)` and `Sha256Hash requestMSC(Address toAddress, BigDecimal requestedMSC)`.

This later could be used in combination with `requestBTC` to break down and remake `createFundedAddress`.