### PR TITLE
Update bitcoin.conf and test scripts

### DIFF
--- a/bitcoin.conf
+++ b/bitcoin.conf
@@ -1,5 +1,7 @@
+server=1
 rpcuser=bitcoinrpc
 rpcpassword=pass
-rpcallowip=*
+rpcallowip=127.0.0.1
 txindex=1
-
+debug=1
+logtimestamps=1

--- a/test-btc-integ-regtest.sh
+++ b/test-btc-integ-regtest.sh
@@ -8,26 +8,26 @@ trap cleanup EXIT
 
 BTCD=copied-artifacts/src/bitcoind
 DATADIR=$HOME/.bitcoin
+LOGDIR=logs
 MSCLOG=/tmp/mastercore.log
 
 # Assume bitcoind built elsewhere and copied by Jenkins Copy Artifact plugin
 chmod +x $BTCD
 
-# Set up bitcoin conf and data dir
+# Setup bitcoin conf and data dir
 mkdir -p $DATADIR
 cp -n bitcoin.conf $DATADIR
 
-# setup logging
-mkdir -p logs
-#rm -f $MSCLOG 
+# Setup logging
+mkdir -p $LOGDIR
 touch $MSCLOG
-ln -sf $MSCLOG logs/mastercore.log
+ln -sf $MSCLOG $LOGDIR/mastercore.log
 
-# remove all regtest data
+# Remove all regtest data
 rm -rf $DATADIR/regtest
 
-# Run Bitcoin in regtest mode
-$BTCD -server -regtest -datadir=$DATADIR -debug > logs/bitcoin.log &
+# Run bitcoind in regtest mode
+$BTCD -regtest -datadir=$DATADIR > $LOGDIR/bitcoin.log &
 BTCSTATUS=$?
 BTCPID=$!
 

--- a/test-msc-consensus-mainnet.sh
+++ b/test-msc-consensus-mainnet.sh
@@ -8,26 +8,26 @@ trap cleanup EXIT
 
 BTCD=copied-artifacts/src/mastercored
 DATADIR=$HOME/.bitcoin
+LOGDIR=logs
 MSCLOG=/tmp/mastercore.log
 
-# Assume mastercored built elsewhere and coied by Jenkins Copy Artifact plugin
+# Assume mastercored built elsewhere and copied by Jenkins Copy Artifact plugin
 chmod +x $BTCD
 
-# Set up bitcoin conf and data dir
+# Setup bitcoin conf and data dir
 mkdir -p $DATADIR
 cp -n bitcoin.conf $DATADIR
 
 # setup logging
-mkdir -p logs
-#rm -f $MSCLOG 
+mkdir -p $LOGDIR
 touch $MSCLOG
-ln -sf $MSCLOG logs/mastercore.log
+ln -sf $MSCLOG $LOGDIR/mastercore.log
 
-# remove Master Protocol persistence directories/files
+# Remove Omni Core persistence directories/files
 rm -rf $DATADIR/MP_*
 
-# Run Bitcoin on main net mode
-$BTCD -server -datadir=$DATADIR -debug > logs/bitcoin.log &
+# Run mastercored in mainnet mode
+$BTCD -datadir=$DATADIR > $LOGDIR/bitcoin.log &
 BTCSTATUS=$?
 BTCPID=$!
 

--- a/test-msc-integ-regtest.sh
+++ b/test-msc-integ-regtest.sh
@@ -8,26 +8,26 @@ trap cleanup EXIT
 
 BTCD=copied-artifacts/src/mastercored
 DATADIR=$HOME/.bitcoin
+LOGDIR=logs
 MSCLOG=/tmp/mastercore.log
 
 # Assume mastercored built elsewhere and copied by Jenkins Copy Artifact plugin
 chmod +x $BTCD
 
-# Set up bitcoin conf and data dir
+# Setup bitcoin conf and data dir
 mkdir -p $DATADIR
 cp -n bitcoin.conf $DATADIR
 
 # setup logging
-mkdir -p logs
-#rm -f $MSCLOG 
+mkdir -p $LOGDIR
 touch $MSCLOG
-ln -sf $MSCLOG logs/mastercore.log
+ln -sf $MSCLOG $LOGDIR/mastercore.log
 
-# remove all regtest data
+# Remove all regtest data
 rm -rf $DATADIR/regtest
 
-# Run Bitcoin in regtest mode
-$BTCD -server -regtest -datadir=$DATADIR -debug > logs/bitcoin.log &
+# Run mastercored in regtest mode
+$BTCD -regtest -datadir=$DATADIR > $LOGDIR/bitcoin.log &
 BTCSTATUS=$?
 BTCPID=$!
 


### PR DESCRIPTION
- Bitcoin Core 0.10 doesn't allow wildcards for `-rpcallowip`
- The options `--server` and `-debug` are shared by all three scripts
- The option `-logtimestamps` adds additional debug information