### PR TITLE
Try fix to avoid "Transaction too large" error

### DIFF
--- a/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToManyOwnersSpec.groovy
+++ b/src/integ/groovy/foundation/omni/test/rpc/sto/MSCSendToManyOwnersSpec.groovy
@@ -126,10 +126,6 @@ class MSCSendToManyOwnersSpec extends BaseRegTestSpec {
 
         assert finalBalanceMSC.balance == 0.0
         assert finalBalanceSPT.balance == 0.0
-
-        // Cleanup
-        sendToAddress(newAddress, getBalance() - 0.1)
-        generateBlock()
     }
 
     @Unroll
@@ -212,10 +208,6 @@ class MSCSendToManyOwnersSpec extends BaseRegTestSpec {
         def finalBalanceSPT = getbalance_MP(actorAddress, currencySPT)
         assert finalBalanceMSC.balance == 0.0
         assert finalBalanceSPT.balance == 0.0
-
-        // Cleanup
-        sendToAddress(newAddress, getBalance() - 0.1)
-        generateBlock()
 
         where:
         maxN    | amountStartPerOwner                    | amountDistributePerOwner               | propertyType


### PR DESCRIPTION
The error is likely caused, because "sendtoaddress"' coin selection selects too many inputs, likely trying to spend all the dust created earlier.

As first fix I tried `sendToAddress(newAddress, getBalance() - 0.1)` to force dust sweeping after each STO round. Because we no longer fund BTC via "sendtoaddress", it might be safe to remove this workaround, which actually causes an error in this case.