### PR TITLE
RegTests: cleanup and sweep unspent outputs

### DIFF
--- a/src/integ/groovy/foundation/omni/BaseRegTestSpec.groovy
+++ b/src/integ/groovy/foundation/omni/BaseRegTestSpec.groovy
@@ -38,7 +38,8 @@ class BaseRegTestSpec extends Specification implements MastercoinClientDelegate,
     }
 
     void cleanupSpec() {
-        // Nothing to clean up for now
+        // Spend almost all coins as fee, to sweep dust
+        consolidateCoins()
     }
 
 }


### PR DESCRIPTION
... to prevent the creation of too large transactions.

See: https://github.com/msgilligan/bitcoin-spock/issues/50