### PR TITLE
BitcoinClient: return result of setGenerate() as Object

### DIFF
--- a/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -178,14 +178,12 @@ public class BitcoinClient extends RPCClient {
      *                        in regtest mode genproclimit is number of blocks to generate immediately
      * @throws IOException
      */
-    public void setGenerate(Boolean generate, Long genproclimit) throws JsonRPCException, IOException {
+    public Object setGenerate(Boolean generate, Long genproclimit) throws JsonRPCException, IOException {
         List<Object> params = createParamList(generate, genproclimit);
-
         Map<String, Object> response = send("setgenerate", params);
 
-
-        String result = (String) response.get("result");
-        assert result == null;
+        Object result = response.get("result");
+        return result;
     }
 
     public void generateBlock() throws JsonRPCException, IOException {


### PR DESCRIPTION
With Bitcoin Core 0.10 the result of "setgenerate" is no longer empty, but a list of block hashes. To support 0.9 and 0.10, returning an Object seems to be the middle ground, as mentioned in #44.