### PR TITLE
Enforce transaction relay fee settings and support listing of RPC commands

### DIFF
--- a/bitcoin-rpc/src/integ/groovy/com/msgilligan/bitcoin/rpc/BitcoinSpec.groovy
+++ b/bitcoin-rpc/src/integ/groovy/com/msgilligan/bitcoin/rpc/BitcoinSpec.groovy
@@ -16,6 +16,17 @@ class BitcoinSpec extends BaseRegTestSpec {
         info.protocolversion >= 70002
     }
 
+    def "Get a list of available commands"() {
+        given:
+        def commands = getCommands()
+
+        expect:
+        commands != null
+        commands.contains('getinfo')
+        commands.contains('help')
+        commands.contains('stop')
+    }
+
     def "Generate a block upon request"() {
         given: "a certain starting height"
         def startHeight = blockCount

--- a/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
+++ b/bitcoin-rpc/src/main/java/com/msgilligan/bitcoin/rpc/BitcoinClient.java
@@ -521,6 +521,48 @@ public class BitcoinClient extends RPCClient {
         return result;
     }
 
+    /**
+     * Returns a list of available commands.
+     *
+     * Commands which are unavailable will not be listed, such as wallet RPCs, if wallet support is disabled.
+     *
+     * @return The list of commands
+     */
+    public List<String> getCommands() throws JsonRPCException, IOException {
+        List<String> commands = new ArrayList<String>();
+        for (String entry : help().split("\n")) {
+            if (!entry.isEmpty() && !entry.matches("== (.+) ==")) {
+                String command = entry.split(" ")[0];
+                commands.add(command);
+            }
+        }
+        return commands;
+    }
+
+    /**
+     * Returns a human readable list of available commands.
+     *
+     * Bitcoin Core 0.9 returns an alphabetical list of commands, and Bitcoin Core 0.10 returns a categorized list of
+     * commands.
+     *
+     * @return The list of commands as string
+     */
+    public String help() throws JsonRPCException, IOException {
+        return help(null);
+    }
+
+    /**
+     * Returns helpful information for a specific command.
+     *
+     * @param command The name of the command to get help for
+     * @return The help text
+     */
+    public String help(String command) throws JsonRPCException, IOException {
+        List<Object> params = createParamList(command);
+        String result = send("help", params);
+        return result;
+    }
+
     public static byte[] hexStringToByteArray(String s) {
         int len = s.length();
         byte[] data = new byte[len / 2];

--- a/omnij-rpc/src/integ/groovy/foundation/omni/BaseRegTestSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/BaseRegTestSpec.groovy
@@ -30,8 +30,11 @@ class BaseRegTestSpec extends Specification implements OmniClientDelegate, OmniT
         }
         assert available
 
-        // Set a default transaction fee, so a known reference value can be used in tests
+        // Set and confirm default fees, so a known reference value can be used in tests
         assert client.setTxFee(stdTxFee)
+        def basicinfo = client.getinfo()
+        assert basicinfo['paytxfee'] == stdTxFee
+        assert basicinfo['relayfee'] == stdRelayTxFee
 
         // Make sure we have enough test coins
         while (getBalance() < minBTCForTests) {

--- a/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToManyOwnersSpec.groovy
+++ b/omnij-rpc/src/integ/groovy/foundation/omni/test/rpc/sto/SendToManyOwnersSpec.groovy
@@ -15,6 +15,8 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
 
     // Print intermediate results
     final static Boolean EXTRA_DEBUG_ROUNDS = false
+    // Number of owners to receive tokens
+    final static Integer NUM_OWNERS = 100
 
     final static BigDecimal stoFeePerAddress = 0.00000001
     final static BigDecimal COIN = 100000000.0
@@ -216,22 +218,22 @@ class SendToManyOwnersSpec extends BaseRegTestSpec {
         assert finalBalanceSPT.balance == 0.0
 
         where:
-        maxN    | amountStartPerOwner                    | amountDistributePerOwner               | propertyType
-        1       | new BigDecimal("1")                    | new BigDecimal("9223372036854775806")  | PropertyType.INDIVISIBLE
-        1       | new BigDecimal("9223372036854775806")  | new BigDecimal("1")                    | PropertyType.INDIVISIBLE
-        100     | new BigDecimal("1")                    | new BigDecimal("1")                    | PropertyType.INDIVISIBLE
-        100     | new BigDecimal("1")                    | new BigDecimal("3")                    | PropertyType.INDIVISIBLE
-        100     | new BigDecimal("1")                    | new BigDecimal("100000000")            | PropertyType.INDIVISIBLE
-        100     | new BigDecimal("100000000")            | new BigDecimal("1")                    | PropertyType.INDIVISIBLE
-        100     | new BigDecimal("100000000")            | new BigDecimal("3")                    | PropertyType.INDIVISIBLE
-        1       | new BigDecimal("0.00000001")           | new BigDecimal("92233720368.54775806") | PropertyType.DIVISIBLE
-        1       | new BigDecimal("92233720368.54775806") | new BigDecimal("0.00000001")           | PropertyType.DIVISIBLE
-        100     | new BigDecimal("0.00000001")           | new BigDecimal("1.00000000")           | PropertyType.DIVISIBLE
-        100     | new BigDecimal("0.00000001")           | new BigDecimal("2.00000000")           | PropertyType.DIVISIBLE
-        100     | new BigDecimal("1.00000000")           | new BigDecimal("0.00000001")           | PropertyType.DIVISIBLE
-        100     | new BigDecimal("1.00000000")           | new BigDecimal("0.00000002")           | PropertyType.DIVISIBLE
-        100     | new BigDecimal("1.00000000")           | new BigDecimal("0.50000000")           | PropertyType.DIVISIBLE
-        100     | new BigDecimal("1.00000000")           | new BigDecimal("3.00000000")           | PropertyType.DIVISIBLE
+        maxN       | amountStartPerOwner                    | amountDistributePerOwner               | propertyType
+        1          | new BigDecimal("1")                    | new BigDecimal("9223372036854775806")  | PropertyType.INDIVISIBLE
+        1          | new BigDecimal("9223372036854775806")  | new BigDecimal("1")                    | PropertyType.INDIVISIBLE
+        NUM_OWNERS | new BigDecimal("1")                    | new BigDecimal("1")                    | PropertyType.INDIVISIBLE
+        NUM_OWNERS | new BigDecimal("1")                    | new BigDecimal("3")                    | PropertyType.INDIVISIBLE
+        NUM_OWNERS | new BigDecimal("1")                    | new BigDecimal("100000000")            | PropertyType.INDIVISIBLE
+        NUM_OWNERS | new BigDecimal("100000000")            | new BigDecimal("1")                    | PropertyType.INDIVISIBLE
+        NUM_OWNERS | new BigDecimal("100000000")            | new BigDecimal("3")                    | PropertyType.INDIVISIBLE
+        1          | new BigDecimal("0.00000001")           | new BigDecimal("92233720368.54775806") | PropertyType.DIVISIBLE
+        1          | new BigDecimal("92233720368.54775806") | new BigDecimal("0.00000001")           | PropertyType.DIVISIBLE
+        NUM_OWNERS | new BigDecimal("0.00000001")           | new BigDecimal("1.00000000")           | PropertyType.DIVISIBLE
+        NUM_OWNERS | new BigDecimal("0.00000001")           | new BigDecimal("2.00000000")           | PropertyType.DIVISIBLE
+        NUM_OWNERS | new BigDecimal("1.00000000")           | new BigDecimal("0.00000001")           | PropertyType.DIVISIBLE
+        NUM_OWNERS | new BigDecimal("1.00000000")           | new BigDecimal("0.00000002")           | PropertyType.DIVISIBLE
+        NUM_OWNERS | new BigDecimal("1.00000000")           | new BigDecimal("0.50000000")           | PropertyType.DIVISIBLE
+        NUM_OWNERS | new BigDecimal("1.00000000")           | new BigDecimal("3.00000000")           | PropertyType.DIVISIBLE
     }
 
 }


### PR DESCRIPTION
See commit details:

- Move magic number of owners in "send to many owners" test to the top
- Set transaction fee and assert transaction relay fees in regtest mode
- Support RPC "help" and listing of all available RPC commands